### PR TITLE
perf: increase default NFC read length to 256 bytes

### DIFF
--- a/lib/src/passport.dart
+++ b/lib/src/passport.dart
@@ -154,10 +154,20 @@ class Passport {
     return EfCOM.fromBytes(await _exec(() => _api.readFileBySFI(EfCOM.SFI)));
   }
 
-  Future<Uint8List> readBySFI(int sfi) async {
+  Future<Uint8List> readBySFI(
+    int sfi, {
+    Uint8List? resumeData,
+    void Function(Uint8List chunk, int offset, int totalLength)? onChunk,
+  }) async {
     await _selectDF1();
 
-    return await _exec(() => _api.readFileBySFI(sfi));
+    return await _exec(
+      () => _api.readFileBySFI(
+        sfi,
+        resumeData: resumeData,
+        onChunk: onChunk,
+      ),
+    );
   }
 
   /// Reads file EF.DG1 from passport.

--- a/lib/src/proto/mrtd_api.dart
+++ b/lib/src/proto/mrtd_api.dart
@@ -154,7 +154,11 @@ class MrtdApi {
   /// Can throw [ICCError] in case when file doesn't exist, read errors or
   /// SM session is not established but required to read file.
   /// Can throw [ComProviderError] in case connection with MRTD is lost.
-  Future<Uint8List> readFileBySFI(int sfi) async {
+  Future<Uint8List> readFileBySFI(
+    int sfi, {
+    Uint8List? resumeData,
+    void Function(Uint8List chunk, int offset, int totalLength)? onChunk,
+  }) async {
     _log.debug("Reading file sfi=0x${sfi.hex()}");
     sfi |= 0x80;
     if(sfi > 0x9F) {
@@ -164,18 +168,53 @@ class MrtdApi {
     // Read chunk of file to obtain file length
     final chunk1 = await icc.readBinaryBySFI(sfi: sfi, offset: 0, ne: _readAheadLength);
     final dtl = TLV.decodeTagAndLength(chunk1.data!);
+    final totalLength = dtl.encodedLen + dtl.length.value;
+    final resumed = resumeData == null
+        ? Uint8List(0)
+        : Uint8List.fromList(resumeData);
+
+    if(resumed.length > totalLength) {
+      throw MrtdApiError("Resume data is longer than the selected file");
+    }
+
+    final comparableLength = resumed.length < chunk1.data!.length
+        ? resumed.length
+        : chunk1.data!.length;
+    for(var i = 0; i < comparableLength; i++) {
+      if(resumed[i] != chunk1.data![i]) {
+        throw MrtdApiError("Resume data does not match the selected file");
+      }
+    }
+
+    var rawFile = resumed;
+    if(rawFile.length < chunk1.data!.length) {
+      final offset = rawFile.length;
+      final missingHeader = Uint8List.fromList(chunk1.data!.sublist(offset));
+      rawFile = Uint8List.fromList(rawFile + missingHeader);
+      onChunk?.call(missingHeader, offset, totalLength);
+    }
 
     // Read the rest of the file
-    final length =  dtl.length.value - (chunk1.data!.length - dtl.encodedLen);
-    final chunk2 = await _readBinary(offset: chunk1.data!.length, length: length);
+    final length = totalLength - rawFile.length;
+    final chunk2 = await _readBinary(
+      offset: rawFile.length,
+      length: length,
+      totalLength: totalLength,
+      onChunk: onChunk,
+    );
 
-    final rawFile = Uint8List.fromList(chunk1.data! + chunk2);
+    rawFile = Uint8List.fromList(rawFile + chunk2);
     assert(rawFile.length == dtl.encodedLen + dtl.length.value);
     return rawFile;
   }
 
   /// Reads [length] long fragment of file starting at [offset].
-  Future<Uint8List> _readBinary({ required int offset, required int length }) async {
+  Future<Uint8List> _readBinary({
+    required int offset,
+    required int length,
+    int? totalLength,
+    void Function(Uint8List chunk, int offset, int totalLength)? onChunk,
+  }) async {
     var data = Uint8List(0);
     while(length > 0) {
       int nRead = length;
@@ -216,9 +255,17 @@ class MrtdApi {
         }
 
         if(rapdu.data != null) {
-          data    = Uint8List.fromList(data + rapdu.data!);
-          offset += rapdu.data!.length;
-          length -= rapdu.data!.length;
+          final chunkOffset = offset;
+          final received = rapdu.data!;
+          final accepted = received.length > length
+              ? Uint8List.fromList(received.sublist(0, length))
+              : Uint8List.fromList(received);
+          data    = Uint8List.fromList(data + accepted);
+          offset += accepted.length;
+          length -= accepted.length;
+          if(accepted.isNotEmpty && totalLength != null) {
+            onChunk?.call(accepted, chunkOffset, totalLength);
+          }
         }
         else {
           _log.warning("No data received when trying to read binary");
@@ -241,17 +288,6 @@ class MrtdApi {
           await _reinitSession?.call();
         }
       }
-    }
-
-    // Verify total received data size is not greater than
-    // requested and remove excess data.
-    // Some passports e.g.: Slovenian on SW:0x6282 (unexpectedEOF)
-    // add possible wrong pad data: 0x000080 instead of 0x800000.
-    if(length < 0) {
-      final newSize = data.length - length.abs();
-      _log.warning("Total read data size is greater than requested, removing last ${length.abs()} byte(s)");
-      _log.debug("  Requested size:$newSize byte(s) actual size:${data.length} byte(s)");
-      data = data.sublist(0, newSize);
     }
 
     return data;

--- a/lib/src/proto/mrtd_api.dart
+++ b/lib/src/proto/mrtd_api.dart
@@ -41,7 +41,7 @@ class MrtdApi {
   // See: Section 4.1 https://www.icao.int/publications/Documents/9303_p10_cons_en.pdf
   static const _defaultSelectP2          = ISO97816_SelectFileP2.returnFCP | ISO97816_SelectFileP2.returnFMD;
   final _log                             = Logger("mrtd.api");
-  static const int _defaultReadLength    = 224; // 256 = expect maximum number of bytes. TODO: in production set it to 224 - JMRTD
+  static const int _defaultReadLength    = 256;
   int _maxRead                           = _defaultReadLength;
   static const int _readAheadLength      = 8;   // Number of bytes to read at the start of file to determine file length.
   Future<void> Function()? _reinitSession;
@@ -258,10 +258,13 @@ class MrtdApi {
   }
 
   void _reduceMaxRead() {
-    if(_maxRead > 224) {
-      _maxRead = 224;         // JMRTD lib's default read size
+    if(_maxRead > 256) {
+      _maxRead = 256;
     }
-    else if(_maxRead > 160) { // Some passports can't handle more then 160 bytes per read
+    else if(_maxRead > 224) {
+      _maxRead = 224;
+    }
+    else if(_maxRead > 160) {
       _maxRead = 160;
     }
     else if(_maxRead > 128) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,4 +31,4 @@ dev_dependencies:
   flutter_test: # needed for flutter_nfc_kit
     sdk: flutter
   lints: ^2.0.0
-  test: 1.30.0
+  test: ^1.25.15

--- a/test/resumable_read_test.dart
+++ b/test/resumable_read_test.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+
+import 'package:dmrtd/dmrtd.dart';
+import 'package:dmrtd/internal.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+class _QueuedProvider extends ComProvider {
+  final List<Object> responses;
+  final List<Uint8List> commands = [];
+
+  _QueuedProvider(this.responses) : super(Logger('resumable-read-test'));
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  bool isConnected() => true;
+
+  @override
+  Future<Uint8List> transceive(Uint8List data) async {
+    commands.add(Uint8List.fromList(data));
+    final response = responses.removeAt(0);
+    if (response is Exception) throw response;
+    return response as Uint8List;
+  }
+}
+
+Uint8List _response(List<int> data) =>
+    Uint8List.fromList([...data, 0x90, 0x00]);
+
+void main() {
+  test('resumes an SFI read from the first unfinished byte', () async {
+    final content = List<int>.generate(300, (index) => index % 256);
+    final file = Uint8List.fromList([0x61, 0x82, 0x01, 0x2c, ...content]);
+    var checkpoint = Uint8List(0);
+
+    final firstProvider = _QueuedProvider([
+      _response(file.sublist(0, 8)),
+      _response(file.sublist(8, 264)),
+      const ComProviderError('Tag was lost'),
+    ]);
+
+    await expectLater(
+      MrtdApi(firstProvider).readFileBySFI(
+        0x02,
+        onChunk: (chunk, offset, totalLength) {
+          expect(offset, checkpoint.length);
+          expect(totalLength, file.length);
+          checkpoint = Uint8List.fromList(checkpoint + chunk);
+        },
+      ),
+      throwsA(isA<ComProviderError>()),
+    );
+    expect(checkpoint.length, 264);
+
+    final resumedChunks = <Uint8List>[];
+    final secondProvider = _QueuedProvider([
+      _response(file.sublist(0, 8)),
+      _response(file.sublist(264)),
+    ]);
+    final result = await MrtdApi(secondProvider).readFileBySFI(
+      0x02,
+      resumeData: checkpoint,
+      onChunk: (chunk, offset, totalLength) {
+        expect(offset, checkpoint.length);
+        expect(totalLength, file.length);
+        resumedChunks.add(chunk);
+      },
+    );
+
+    expect(result, file);
+    expect(resumedChunks, hasLength(1));
+    expect(resumedChunks.single, file.sublist(264));
+    expect(
+      secondProvider.commands[1].sublist(0, 4),
+      [0x00, 0xb0, 0x01, 0x08],
+    );
+  });
+
+  test('rejects resume data from a different file', () async {
+    final file = [0x61, 0x03, 0x01, 0x02, 0x03];
+    final provider = _QueuedProvider([_response(file)]);
+
+    await expectLater(
+      MrtdApi(provider).readFileBySFI(
+        0x02,
+        resumeData: Uint8List.fromList([0x62]),
+      ),
+      throwsA(isA<MrtdApiError>()),
+    );
+  });
+}


### PR DESCRIPTION
Raise the initial MRTD read buffer and fallback ladder to reduce round-trips during passport NFC reads on Android.